### PR TITLE
string match mode, group items, allow disabling URL control for certain filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Please see the demo for sample code. Use:
 ### v4.0.0
 
 - `filter-KEY_NAME--hide` CSS is now added automatically via the component—works alongside manually added CSS for proper progressive enhancement.
+- New setting `filter-match-mode` to control if string compares should match the whole string (`strict`, default) or substrings (`contains`).
 
 ### v3.0.4
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Please see the demo for sample code. Use:
 * Use `<filter-container delimiter=",">` if your content elements may have more than one filter value assigned (in this example delimited by a comma).
   * For example, Egypt is in both Africa and Asia: `<li data-filter-continent="africa,asia">Egypt</li>`
 
+* You can group filter result items using `data-filter-group-item` data attribute by setting the same group name. If you set `data-filter-group-label` to the same group name, the elenent will be hidden if no items from the group are visible.
+  * In the example below, filtering for "fruit" will remove the "Group B" headline as well:
+  ```html
+  <h2 data-filter-group-label="groupA">Group A</h2>
+  <span data-filter-group-item="groupA" data-filter-type="fruit">Apple</span>
+  <span data-filter-group-item="groupA" data-filter-type="fruit">Banana</span>
+  <h2 data-filter-group-label="groupB">Group B</h2>
+  <span data-filter-group-item="groupB" data-filter-type="vegetable">Carrot</span>
+  <span data-filter-group-item="groupB" data-filter-type="vegetable">Tomato</span>
+  ```
+
 ## Changelog
 
 ### v4.0.0
@@ -43,6 +54,7 @@ Please see the demo for sample code. Use:
 - `filter-KEY_NAME--hide` CSS is now added automatically via the component—works alongside manually added CSS for proper progressive enhancement.
 - New setting `filter-match-mode` to control if string compares should match the whole string (`strict`, default) or substrings (`contains`).
 - Filters can be excluded from URL manipulation by setting `leave-url-alone-[filter name]` on `<filter-container>`
+- New feature "filter groups" which allows hiding elements (e.g. labels) when all items of the same group are hidden.
 
 ### v3.0.4
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please see the demo for sample code. Use:
 - New setting `filter-match-mode` to control if string compares should match the whole string (`strict`, default) or substrings (`contains`).
 - Filters can be excluded from URL manipulation by setting `leave-url-alone-[filter name]` on `<filter-container>`
 - New feature "filter groups" which allows hiding elements (e.g. labels) when all items of the same group are hidden.
+- New setting `filter-input-delimiter-[filter name]` that allows supplying a delimiter to split user input into multiple tokens that are matched instead of the full string.
 
 ### v3.0.4
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Please see the demo for sample code. Use:
 
 - `filter-KEY_NAME--hide` CSS is now added automatically via the component—works alongside manually added CSS for proper progressive enhancement.
 - New setting `filter-match-mode` to control if string compares should match the whole string (`strict`, default) or substrings (`contains`).
+- Filters can be excluded from URL manipulation by setting `leave-url-alone-[filter name]` on `<filter-container>`
 
 ### v3.0.4
 

--- a/filter-container.js
+++ b/filter-container.js
@@ -4,6 +4,7 @@ class FilterContainer extends HTMLElement {
     valueDelimiter: "delimiter",
     leaveUrlAlone: "leave-url-alone",
     mode: "filter-mode",
+    matchMode: "filter-match-mode",
     bind: "data-filter-key",
     results: "data-filter-results",
     resultsExclude: "data-filter-results-exclude",
@@ -104,6 +105,23 @@ class FilterContainer extends HTMLElement {
     return this.modes[key];
   }
 
+  getMatchMode(key) {
+    if(!this.matchModes) {
+      this.matchModes = {};
+    }
+    if(!this.matchModes[key]) {
+      this.matchModes[key] = this.getAttribute(`${FilterContainer.attrs.matchMode}-${key}`);
+    }
+    if(!this.matchModes[key]) {
+      if(!this.globalMatchMode) {
+        this.globalMatchMode = this.getAttribute(FilterContainer.attrs.matchMode);
+      }
+      return this.globalMatchMode;
+    }
+
+    return this.matchModes[key];
+  }
+
   bindEvents() {
     this.addEventListener("input", e => {
       let closest = e.target.closest(`[${FilterContainer.attrs.bind}]`);
@@ -194,7 +212,7 @@ class FilterContainer extends HTMLElement {
     this._applyMapForKey(key, map);
   }
 
-  _hasValue(needle, haystack = [], mode = "any") {
+  _hasValue(needle, haystack = [], mode = "any", matchMode = "strict") {
     if(!haystack || !haystack.length || !Array.isArray(haystack)) {
       return false;
     }
@@ -203,11 +221,19 @@ class FilterContainer extends HTMLElement {
       needle = [needle];
     }
 
-    // all must match
+    const matcher = (lookingFor) => {
+      return (val) => {
+        if (matchMode === 'contains') {
+          return lookingFor.toLowerCase().includes(val.toLowerCase())
+        }
+        return val === lookingFor
+      }
+    };
+    // all must match    
     if(mode === "all") {
       let found = true;
       for(let lookingFor of haystack) {
-        if(!needle.some((val) => val === lookingFor)) {
+        if(!needle.some(matcher(lookingFor))) {
           found = false;
         }
       }
@@ -216,7 +242,7 @@ class FilterContainer extends HTMLElement {
 
     for(let lookingFor of needle) {
       // has any, return true
-      if(haystack.some((val) => val === lookingFor)) {
+      if(haystack.some(matcher(lookingFor))) {
         return true;
       }
     }
@@ -231,7 +257,8 @@ class FilterContainer extends HTMLElement {
     let haystack = (element.getAttribute(attributeName) || "").split(this.valueDelimiter);
     let key = this.getKeyFromAttributeName(attributeName);
     let mode = this.getFilterMode(key);
-    if(hasAttr && this._hasValue(haystack, values, mode)) {
+    let matchMode = this.getMatchMode(key);
+    if(hasAttr && this._hasValue(haystack, values, mode, matchMode)) {
       return true;
     }
     return false;

--- a/filter-container.js
+++ b/filter-container.js
@@ -85,7 +85,7 @@ class FilterContainer extends HTMLElement {
   }
 
   getKeyFromAttributeName(attributeName) {
-    return attributeName.substr("data-filter-".length);
+    return attributeName.substring("data-filter-".length);
   }
 
   getFilterMode(key) {
@@ -349,7 +349,7 @@ class FilterContainer extends HTMLElement {
   getUrlSearchValue() {
     let s = window.location.search;
     if(s.startsWith("?")) {
-      return s.substr(1);
+      return s.substring(1);
     }
     return s;
   }

--- a/filter-container.js
+++ b/filter-container.js
@@ -10,6 +10,7 @@ class FilterContainer extends HTMLElement {
     resultsExclude: "data-filter-results-exclude",
     filterGroupLabel: "data-filter-group-label",
     filterGroupItem: "data-filter-group-item",
+    inputDelimiter: "filter-input-delimiter",
   };
 
   static register(tagName) {
@@ -165,7 +166,15 @@ class FilterContainer extends HTMLElement {
           values.push(formElement.value);
         }
       } else {
-        values.push(formElement.value);
+        // split values by filter-input-delimiter- if set
+        let delimiter = this.getAttribute(FilterContainer.attrs.inputDelimiter + '-' + key);
+        if (delimiter && delimiter !== '') {
+          for (let splitValue of formElement.value.split(delimiter)) {
+            values.push(typeof splitValue === 'string' ? splitValue.trim() : splitValue);
+          }
+        } else {
+          values.push(formElement.value);
+        }
       }
     }
 
@@ -389,6 +398,12 @@ class FilterContainer extends HTMLElement {
     let params = new URLSearchParams(this.getUrlSearchValue());
     let keyParamsStr = params.getAll(key).sort().join(",");
     let valuesStr = values.slice().sort().join(",");
+
+    // respect multivalue delimiter if set
+    let delimiter = this.getAttribute(FilterContainer.attrs.inputDelimiter + '-' + key)
+    if (delimiter) {
+      values = [values.join(delimiter)]
+    }
 
     if(keyParamsStr !== valuesStr) {
       params.delete(key);

--- a/filter-container.js
+++ b/filter-container.js
@@ -167,7 +167,7 @@ class FilterContainer extends HTMLElement {
       }
     }
 
-    if(!this.hasAttribute(FilterContainer.attrs.leaveUrlAlone)) {
+    if(!this.hasAttribute(FilterContainer.attrs.leaveUrlAlone) && !this.hasAttribute(FilterContainer.attrs.leaveUrlAlone + '-' + key)) {
       this.updateUrl(key, values);
     }
 

--- a/filter-container.js
+++ b/filter-container.js
@@ -8,6 +8,8 @@ class FilterContainer extends HTMLElement {
     bind: "data-filter-key",
     results: "data-filter-results",
     resultsExclude: "data-filter-results-exclude",
+    filterGroupLabel: "data-filter-group-label",
+    filterGroupItem: "data-filter-group-item",
   };
 
   static register(tagName) {
@@ -17,7 +19,7 @@ class FilterContainer extends HTMLElement {
   }
 
   getCss(keys) {
-    return `${keys.map(key => `.filter-${key}--hide`).join(", ")} {
+    return `${keys.map(key => `.filter-${key}--hide`).join(", ")},.filter-group--hide {
   display: none;
 }`;
   }
@@ -188,12 +190,34 @@ class FilterContainer extends HTMLElement {
       return;
     }
 
+    let cls = `filter-${key}--hide`;
+    const filterGroupsToCheck = []
     for(let [element, isVisible] of map) {
-      let cls = `filter-${key}--hide`;
       if(isVisible) {
         element.classList.remove(cls);
       } else {
         element.classList.add(cls);
+      }
+
+      // Update filter group label visibility
+      if (element.hasAttribute(FilterContainer.attrs.filterGroupItem)) {
+        let filterGroupName = element.getAttribute(FilterContainer.attrs.filterGroupItem)
+        filterGroupsToCheck.push(filterGroupName);
+      }
+    }
+
+    for (const filterGroupName of filterGroupsToCheck) {
+      const groupLabelElements = this.querySelectorAll(`[${FilterContainer.attrs.filterGroupLabel}="${filterGroupName}"]`)
+      if (filterGroupName.length && groupLabelElements.length) {
+        const allGroupElements = this.querySelectorAll(`[${FilterContainer.attrs.filterGroupItem}="${filterGroupName}"]`)
+        const visibleElements = [...allGroupElements].filter(this.elementIsVisible)
+        for (const groupLabelEl of groupLabelElements) {
+          if (visibleElements.length) {
+            groupLabelEl.classList.remove('filter-group--hide');
+          } else {
+            groupLabelEl.classList.add('filter-group--hide');
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Add new setting  `filter-match-mode` to control how strings should be matched.
Per default it matches strictly (string completely equals the input).
But it allows matching substrings:

`<filter-container oninit delimiter="," filter-mode="any" filter-match-mode="contains">`

or restrict it to input named "title":

`<filter-container oninit delimiter="," filter-mode="any" filter-match-mode-title="contains">`

---

Additional features included:

* Allow disabling URL control by filter name
* Filter groups: filter items can be added to a group. Labels for that group are hidden when no items from that group is visible